### PR TITLE
Add default response format for requests non-json requests

### DIFF
--- a/lib/routes/_schedule.test.js
+++ b/lib/routes/_schedule.test.js
@@ -48,9 +48,7 @@ describe('routes/_schedule', () => {
           isAuthenticated: jest.fn(() => false)
         },
         res = {
-          status: jest.fn(),
-          json: jest.fn(),
-          default: jest.fn()
+          status: jest.fn(() => ({ format: jest.fn() }))
         };
 
       routes.route.post(req, res);
@@ -93,9 +91,7 @@ describe('routes/_schedule', () => {
           isAuthenticated: jest.fn(() => false)
         },
         res = {
-          status: jest.fn(),
-          json: jest.fn(),
-          default: jest.fn()
+          status: jest.fn(() => ({ format: jest.fn() }))
         };
 
       routes.route.del(req, res);

--- a/lib/services/responses.js
+++ b/lib/services/responses.js
@@ -106,11 +106,11 @@ function accept(options) {
     let message, code,
       matchedType = req.accepts(acceptableTypes);
 
-    if (matchedType) {
+    if (req.is(matchedType)) {
       next();
     } else {
       code = 406;
-      message = `${req.get('Accept')} not acceptable`;
+      message = `${req.get('content-type')} not acceptable`;
       res.set('Accept', acceptableTypes.join(', ').toLowerCase());
       sendDefaultResponseForCode(code, message, res, options);
     }

--- a/lib/services/responses.js
+++ b/lib/services/responses.js
@@ -88,9 +88,10 @@ function sendJSONErrorCode(code, message, res, extras) {
  * @param {Object} [extras]
  */
 function sendDefaultResponseForCode(code, message, res, extras) {
-  res.status(code);
-  res.json(sendJSONErrorCode(code, message, res, extras));
-  res.default(sendDefaultErrorCode(code, res));
+  res.status(code).format({
+    json: sendJSONErrorCode(code, message, res, extras),
+    default: sendDefaultErrorCode(code, res)
+  });
 }
 
 /**

--- a/lib/services/responses.js
+++ b/lib/services/responses.js
@@ -106,11 +106,11 @@ function accept(options) {
     let message, code,
       matchedType = req.accepts(acceptableTypes);
 
-    if (req.is(matchedType)) {
+    if (matchedType) {
       next();
     } else {
       code = 406;
-      message = `${req.get('content-type')} not acceptable`;
+      message = `${req.get('Accept')} not acceptable`;
       res.set('Accept', acceptableTypes.join(', ').toLowerCase());
       sendDefaultResponseForCode(code, message, res, options);
     }

--- a/lib/services/responses.test.js
+++ b/lib/services/responses.test.js
@@ -152,7 +152,8 @@ describe('services/responses', () => {
     test('it should call next function if accepts header matches', () => {
       const options = { accept: ['application/json'] },
         req = {
-          accepts: jest.fn((acceptableType) => acceptableType.includes('application/json'))
+          accepts: jest.fn((acceptableType) => acceptableType.includes('application/json')),
+          is: jest.fn(() => true)
         },
         res = {
           status: jest.fn(() => ({ format: jest.fn() })),
@@ -170,7 +171,8 @@ describe('services/responses', () => {
       const options = { accept: ['text/html'] },
         req = {
           accepts: jest.fn((acceptableType) => acceptableType.includes('application/json')),
-          get: jest.fn()
+          get: jest.fn(),
+          is: jest.fn(() => false)
         },
         res = {
           set: jest.fn(),
@@ -183,7 +185,7 @@ describe('services/responses', () => {
       expect(req.accepts.mock.calls.length).toBe(1);
       expect(next.mock.calls.length).toBe(0);
       expect(req.get.mock.calls.length).toBe(1);
-      expect(req.get.mock.calls[0][0]).toBe('Accept');
+      expect(req.get.mock.calls[0][0]).toBe('content-type');
       expect(res.set.mock.calls.length).toBe(1);
       expect(res.set.mock.calls[0][0]).toBe('Accept');
       expect(res.status.mock.calls.length).toBe(1);

--- a/lib/services/responses.test.js
+++ b/lib/services/responses.test.js
@@ -152,8 +152,7 @@ describe('services/responses', () => {
     test('it should call next function if accepts header matches', () => {
       const options = { accept: ['application/json'] },
         req = {
-          accepts: jest.fn((acceptableType) => acceptableType.includes('application/json')),
-          is: jest.fn(() => true)
+          accepts: jest.fn((acceptableType) => acceptableType.includes('application/json'))
         },
         res = {
           status: jest.fn(() => ({ format: jest.fn() })),
@@ -171,8 +170,7 @@ describe('services/responses', () => {
       const options = { accept: ['text/html'] },
         req = {
           accepts: jest.fn((acceptableType) => acceptableType.includes('application/json')),
-          get: jest.fn(),
-          is: jest.fn(() => false)
+          get: jest.fn()
         },
         res = {
           set: jest.fn(),
@@ -185,7 +183,7 @@ describe('services/responses', () => {
       expect(req.accepts.mock.calls.length).toBe(1);
       expect(next.mock.calls.length).toBe(0);
       expect(req.get.mock.calls.length).toBe(1);
-      expect(req.get.mock.calls[0][0]).toBe('content-type');
+      expect(req.get.mock.calls[0][0]).toBe('Accept');
       expect(res.set.mock.calls.length).toBe(1);
       expect(res.set.mock.calls[0][0]).toBe('Accept');
       expect(res.status.mock.calls.length).toBe(1);
@@ -207,3 +205,4 @@ describe('services/responses', () => {
     });
   });
 });
+

--- a/lib/services/responses.test.js
+++ b/lib/services/responses.test.js
@@ -91,11 +91,10 @@ describe('services/responses', () => {
         middleware = allow(options),
         next = jest.fn(),
         set = jest.fn(),
-        status = jest.fn(),
-        json = jest.fn();
+        status = jest.fn(() => ({ format: jest.fn() }));
 
       ['put', 'delete'].forEach(method => {
-        middleware({ method }, { set, status, json, default: jest.fn() }, next);
+        middleware({ method }, { set, status }, next);
       });
 
       expect(next.mock.calls.length).toBe(0);
@@ -135,18 +134,17 @@ describe('services/responses', () => {
   describe('sendDefaultResponseForCode', () => {
     test('calls format to get default response type', () => {
       const code = 400,
+        format = jest.fn(),
         res = {
-          status: jest.fn(),
-          json: jest.fn(),
-          default: jest.fn()
+          status: jest.fn(() => ({ format })),
+          json: jest.fn()
         };
 
       sendDefaultResponseForCode(code, 'some message', res, {});
 
       expect(res.status.mock.calls.length).toBe(1);
       expect(res.status.mock.calls[0][0]).toEqual(code);
-      expect(res.json.mock.calls.length).toBe(1);
-      expect(res.default.mock.calls.length).toBe(1);
+      expect(format.mock.calls.length).toBe(1);
     });
   });
 
@@ -157,9 +155,8 @@ describe('services/responses', () => {
           accepts: jest.fn((acceptableType) => acceptableType.includes('application/json'))
         },
         res = {
-          status: jest.fn(),
-          json: jest.fn(),
-          default: jest.fn()
+          status: jest.fn(() => ({ format: jest.fn() })),
+          json: jest.fn()
         },
         next = jest.fn();
 
@@ -177,9 +174,7 @@ describe('services/responses', () => {
         },
         res = {
           set: jest.fn(),
-          status: jest.fn(),
-          json: jest.fn(),
-          default: jest.fn()
+          status: jest.fn(() => ({ format: jest.fn() }))
         },
         next = jest.fn();
 
@@ -191,16 +186,16 @@ describe('services/responses', () => {
       expect(req.get.mock.calls[0][0]).toBe('Accept');
       expect(res.set.mock.calls.length).toBe(1);
       expect(res.set.mock.calls[0][0]).toBe('Accept');
-      expect(res.json.mock.calls.length).toBe(1);
+      expect(res.status.mock.calls.length).toBe(1);
+      expect(res.status.mock.calls[0][0]).toBe(406);
     });
   });
 
   describe('unauthorized', () => {
     test('send unauthorized response from a response object', () => {
       const res = {
-        status: jest.fn(),
-        json: jest.fn(),
-        default: jest.fn()
+        set: jest.fn(),
+        status: jest.fn(() => ({ format: jest.fn() }))
       };
 
       unauthorized(res);


### PR DESCRIPTION
res.default() isn't actually a function, have to use .format() to set a default response