### PR TITLE
send an empty response on errors

### DIFF
--- a/lib/services/schedule.js
+++ b/lib/services/schedule.js
@@ -120,7 +120,11 @@ function unschedule(uri, user) {
       });
 
       return db.db.patchMeta(pageUri, meta);
-    }).catch(errorLogger);
+    }).catch((e) => {
+      errorLogger(e);
+
+      return {};
+    });
 }
 
 /**


### PR DESCRIPTION
so as not to break kiln, which is expecting JSON responses from schedule events