### PR TITLE
Publishes schedulePage and unschedulePage to event bus

### DIFF
--- a/lib/services/bus.js
+++ b/lib/services/bus.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function setPublish(publish) {
+  module.exports.publish = publish;
+}
+
+module.exports.setPublish = setPublish;

--- a/lib/services/bus.test.js
+++ b/lib/services/bus.test.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const bus = require('./bus');
+
+describe('services/bus', () => {
+  const fn = () => 'a setter';
+
+  describe('setPublish', () => {
+    test('if setPublish is a setter', () => {
+      bus.setPublish(fn);
+      expect(bus.publish).toBe(fn);
+    });
+  });
+
+});

--- a/lib/services/init.js
+++ b/lib/services/init.js
@@ -2,15 +2,18 @@
 
 const db = require('./db'),
   routes = require('./routes'),
+  bus = require('./bus'),
   schedule = require('./schedule');
 
 /**
  * Initializes plugin.
  * @param {Object} router
  * @param {Object} storage
+ * @param {Function} publish to the event bus
  * @return {Promise}
  */
-function onInit(router, storage) {
+function onInit(router, storage, publish) {
+  bus.setPublish(publish);
   return db(storage)
     .then(() => routes(router))
     .then(() => {

--- a/lib/services/init.test.js
+++ b/lib/services/init.test.js
@@ -2,12 +2,14 @@
 
 const init = require('./init'),
   db = require('./db'),
+  bus = require('./bus'),
   routes = require('./routes'),
   schedule = require('./schedule'),
   router = {},
   storage = {};
 
 jest.mock('./db');
+jest.mock('./bus');
 jest.mock('./routes');
 jest.mock('./schedule');
 
@@ -32,6 +34,7 @@ describe('init', () => {
 
       return init(router, storage).then(() => {
         expect(db.mock.calls.length).toBe(1);
+        expect(bus.setPublish.mock.calls.length).toBe(1);
         expect(db.mock.calls[0][0]).toEqual(storage);
         expect(routes.mock.calls.length).toBe(1);
         expect(routes.mock.calls[0][0]).toEqual(router);

--- a/lib/services/schedule.js
+++ b/lib/services/schedule.js
@@ -9,6 +9,7 @@ const _ = require('lodash'),
   db = require('./db'),
   references = require('./references'),
   buf = require('./buffer'),
+  bus = require('./bus'),
   rest = require('./rest'),
   publishProperty = 'publish',
   scheduledAtProperty = 'at',
@@ -41,7 +42,7 @@ function publishExternally(url) {
           log('error', `failed to publish url from schedule: [${res.status}] ${res.statusText}`, { url, status: res.status });
         }
 
-        return db.db.patchMeta(uri, { scheduled: false, scheduledTime: null }).then((meta) => res.json());
+        return db.db.patchMeta(uri, { scheduled: false, scheduledTime: null }).then(() => res.json());
       });
   });
 }
@@ -105,6 +106,7 @@ function unschedule(uri, user) {
   return del(uri)
     .then((data) => {
       const publish = data[publishProperty];
+
       pageUri = publish.replace(/http:\/\/|https:\/\//g, '');
 
       return db.db.getMeta(pageUri);
@@ -120,7 +122,11 @@ function unschedule(uri, user) {
       });
 
       return db.db.patchMeta(pageUri, meta);
-    }).catch((e) => {
+    })
+    .then(() => {
+      return bus.publish('unschedulePage', { uri: pageUri, user });
+    })
+    .catch((e) => {
       errorLogger(e);
 
       return {};
@@ -153,6 +159,9 @@ function post(uri, data, user) {
       });
 
       return db.db.patchMeta(pageUri, meta);
+    })
+    .then(() => {
+      return bus.publish('schedulePage', { uri: pageUri, data, user });
     })
     .then(() => data)
     .catch(errorLogger);

--- a/lib/services/schedule.test.js
+++ b/lib/services/schedule.test.js
@@ -20,11 +20,13 @@ const {
   } = require('./schedule'),
   rest = require('./rest'),
   db = require('./db'),
+  bus = require('./bus'),
   logger = jest.fn();
 
 jest.mock('./rest');
 jest.mock('./db');
 setLog(logger);
+bus.publish = jest.fn( () => Promise.resolve({}) );
 
 describe('services/schedule', () => {
   describe('createScheduleObjectKey', () => {
@@ -189,7 +191,7 @@ describe('services/schedule', () => {
       db.deleteItem.mockResolvedValue(Promise.resolve({}));
 
       return unschedule(uri, user).then(() => {
-        expect(db.deleteItem.mock.calls.length).toBe(1)
+        expect(db.deleteItem.mock.calls.length).toBe(1);
       });
     });
 
@@ -215,8 +217,9 @@ describe('services/schedule', () => {
         expect(db.db.getMeta.mock.calls[0][0]).toBe('some.com/url');
         expect(db.db.patchMeta.mock.calls.length).toBe(1);
         expect(db.db.patchMeta.mock.calls[0][1].scheduled).toBe(false);
+        expect(bus.publish.mock.calls.length).toBe(1);
       });
-    })
+    });
   });
 
   describe('post', () => {
@@ -232,6 +235,7 @@ describe('services/schedule', () => {
 
       return post(uri, data, {}).then(() => {
         expect(db.insertItem.mock.calls.length).toBe(1);
+        expect(bus.publish.mock.calls.length).toBe(1);
         expect(db.insertItem.mock.calls[0][0]).toBe(newRef);
         expect(db.insertItem.mock.calls[0][1]).toBe(data);
       });


### PR DESCRIPTION
### Description of Changes
- Adds amphora's event bus and publishes `schedulePage` and `unschedulePage` events to it.
- Fixes linting errors so `npm run test` passes.